### PR TITLE
Add stdio MCP entry point for Claude Code integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "zygomorphic": {
+      "command": "npx",
+      "args": ["tsx", "scripts/mcp-stdio.ts"]
+    },
     "postgres": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://rhizome@localhost/zygomorphic"]

--- a/scripts/mcp-stdio.ts
+++ b/scripts/mcp-stdio.ts
@@ -1,0 +1,27 @@
+/**
+ * Stdio entry point for the zygomorphic MCP server.
+ * Loads the graph from Postgres, wires up the orchestrator,
+ * and exposes all MCP tools over stdin/stdout.
+ */
+import { Orchestrator } from '../src/lib/orchestrator.js';
+import { startStdioServer } from '../src/lib/mcp.js';
+import * as db from '../src/lib/db.js';
+
+async function main() {
+  const graph = await db.loadFullGraph();
+  const orch = new Orchestrator();
+  orch.dispatch({ type: 'GRAPH_LOADED', graph });
+
+  await startStdioServer(
+    graph,
+    (event) => orch.dispatch(event),
+    (id, author) => orch.deleteComment(id, author),
+    (id, author, content) => orch.editComment(id, author, content),
+    (id, author, vote) => orch.voteComment(id, author, vote),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/mcp-stdio.ts` — boots the Orchestrator from Postgres and calls `startStdioServer`, exposing all 13 graph tools over stdin/stdout
- Registers the `zygomorphic` server in `.mcp.json` so Claude Code connects to it automatically on startup

## Test plan

- [ ] Reload MCP servers in Claude Code and verify `zygomorphic` appears connected
- [ ] Call `get_overview` to confirm graph loads from Postgres
- [ ] Create a node via `create_node` and verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)