### PR TITLE
Close migration gaps: validators, conditional trace, live factoring

### DIFF
--- a/migration-gaps.md
+++ b/migration-gaps.md
@@ -1,0 +1,295 @@
+# Migration Gap Analysis: What Tropical Doesn't Cover
+
+Tropical's categorical core (term language, type inference, optimizer, dependency graph, toposort, cycle detection, morphism registry) migrates to zygomorphic with type-level renames and covers roughly 40% of the architecture. This document covers the remaining 60%.
+
+---
+
+## 1. ArtifactType and ValidatorSpec (arch \S1, \S6)
+
+PR 32's `ValidatorSpec` has 4 ad-hoc kinds (`llm_output`, `valid_json`, `compiles`, `passes_tests`). The architecture specifies a different taxonomy:
+
+```typescript
+type ValidatorSpec =
+  | { kind: 'command'; command: string; args: string[]; expectedExit: number }
+  | { kind: 'schema'; schema: JSONSchema }
+  | { kind: 'tensor'; checks: ValidatorSpec[] }       // parallel independent checks
+  | { kind: 'sequence'; steps: ValidatorSpec[] }      // sequential dependent checks
+  | { kind: 'human'; prompt: string }                 // requires human judgment
+  | { kind: 'none' }                                  // unvalidatable, must factor
+```
+
+Key differences from PR 32:
+- `tensor` and `sequence` are **composed validators** (theorems, not axioms) -- they combine primitives
+- `none` is the **factoring pressure mechanism**: a morphism with `none` codomain validator cannot execute and must be decomposed
+- `schema` validates against JSON Schema, not just parsability
+- `command` generalizes `compiles` and `passes_tests` into a single shell-exec primitive
+- `human` introduces human-in-the-loop as a first-class validator kind
+
+The validator IS the type. `ArtifactType` is not an abstract label -- it's a named executable predicate. Composition validity is subtyping: `cod(f) <: dom(g)` means f's output satisfies g's input validator.
+
+### Bootstrap kernel (arch \S6.5)
+
+Five primitive validators that exist before the system runs:
+
+1. `is_valid_json(schema)` -- parse + schema check
+2. `is_valid_syntax(language)` -- call language parser
+3. `passes_tests(suite)` -- run test harness
+4. `matches_regex(pattern)` -- string validation
+5. `human_review(prompt)` -- human-in-the-loop
+
+These are axioms. Composed validators (tensor/sequence of primitives) are theorems.
+
+---
+
+## 2. Conditional Trace (arch \S1.3, \S1.4)
+
+This is the single biggest semantic divergence from tropical.
+
+Tropical's trace has product-type codomain: `A ⊗ S -> B ⊗ S`. State always feeds back. This models DSP feedback loops where the loop always runs.
+
+Zygomorphic's trace has **sum-type codomain**: `A ⊗ S -> B + S`. Left injection (B) exits the trace. Right injection (S) feeds back with error context. The trace only emits through the Output path.
+
+This domesticates LLM nondeterminism: the output type is a **guarantee**, not a probability. The retry loop for "produce valid code":
+
+```
+trace(Error, null,
+  compose(prompt_agent, validate)
+  with feedback: format_error
+)
+```
+
+### What this requires
+
+- A sum type in the type system (tropical has `SumType` as an opaque named type, but not as a structural `Either<A, B>` with injection/projection)
+- Modified `splitTraceType` that extracts the state type from a sum codomain rather than a product codomain
+- Modified trace execution semantics: check which injection the output is, branch on it
+- The three atoms (arch \S9): `prompt_agent`, `validate`, `format_error` -- everything else is composition around these
+
+---
+
+## 3. 2-Cell Structure: Rewrite Type (arch \S3)
+
+Factoring is not a side operation on the graph. It IS a 2-morphism. PR 32's `factor.ts` has a basic `applyFactoring` function but no 2-cell type, no inverse, no composition.
+
+### Required type
+
+```typescript
+type Rewrite =
+  | { tag: 'id_2'; cell: Term }                                    // leave unchanged
+  | { tag: 'factor'; source: Term; target: Term;
+      intermediate: ArtifactType; first: Term; second: Term;
+      autonomy: Autonomy }                                         // f => g . h
+  | { tag: 'fuse'; source: Term; target: Term }                   // g . h => f (inverse)
+  | { tag: 'vertical'; first: Rewrite; second: Rewrite }          // factor, then factor child
+  | { tag: 'horizontal'; left: Rewrite; right: Rewrite }          // factor parallel branches
+```
+
+### 2-cell type checker
+
+Verifies boundary preservation: `dom(source) = dom(target)` and `cod(source) = cod(target)`. Factoring must preserve the morphism's typed interface.
+
+### Rewind
+
+Every factoring has an inverse (fuse). Rewindability is typed -- the system guarantees every factoring is undoable. The 2-cell log (git history of morphism files) preserves context without imposing tree structure.
+
+### Connection to \S4 (Generic Toolkit)
+
+The 2-cell structure is not a second implementation. It's the same `CellOps<Obj, Cell>` interface, instantiated at a different level:
+
+| | Level 1 (execution) | Level 2 (planning) |
+|---|---|---|
+| Obj | ArtifactType | Term |
+| Cell | Term | Rewrite |
+| source | dom(term) | original morphism |
+| target | cod(term) | factored composition |
+
+---
+
+## 4. Generic CellOps\<Obj, Cell\> Toolkit (arch \S4)
+
+The type checker, optimizer, and composition logic should be written once and instantiated at each level:
+
+```typescript
+interface CellOps<Obj, Cell> {
+  source(cell: Cell): Obj;
+  target(cell: Cell): Obj;
+  id(obj: Obj): Cell;
+  compose(first: Cell, second: Cell): Cell;
+  tensor(left: Cell, right: Cell): Cell;
+  objEqual(a: Obj, b: Obj): boolean;
+}
+
+function typeCheck<Obj, Cell>(ops: CellOps<Obj, Cell>, cell: Cell): { source: Obj; target: Obj }
+function optimize<Obj, Cell>(ops: CellOps<Obj, Cell>, cell: Cell): Cell
+```
+
+Tropical's `inferType` and `optimize` are concrete (hardcoded to `PortType`/`Term`). They need to be lifted to this generic interface so the same code handles both execution-level type checking and planning-level (2-cell) type checking.
+
+The trace at level N handles "try, fail, retry" at that level -- no N+1 cells needed. Traces are the regress-stopper.
+
+---
+
+## 5. Signal/Slot Executor (arch \S5)
+
+PR 32's executor is a linear pipeline: flatten to list, iterate sequentially. The architecture specifies a fundamentally different model.
+
+### Core semantics
+
+- Each output wire is a signal; each input wire is a slot
+- A node fires when **all** its slots are filled
+- No global barrier, no epochs -- maximal async parallelism
+- Topological sort derives tensor/compose from declared dependencies
+- Critical path emerges from signal propagation
+
+### Design principle
+
+No component has global graph visibility. The dependency structure is encoded in the wiring. Any coordinator with global visibility reintroduces the flat-planner cognitive load the system eliminates. Locality is load-bearing.
+
+### Tensor semantics
+
+`f ⊗ g` means causal independence -- no data dependency between branches. Independence is ENFORCED by workspace isolation: tensor decomposition produces parallel git branches. Branches share no mutable state. A merge conflict between tensor branches is a type error surfaced late.
+
+### Dynamic graph mutation
+
+Lock-free. Factoring at runtime is append-only: create nodes, wire them, set forwarding pointer from original output slot to new subgraph's terminal, enqueue. Existing concurrent nodes never read new structure. Rewind is localized cancellation owned by the trace that created the region.
+
+### Implementation notes
+
+This is the highest-effort new component. It requires:
+- An event loop / task scheduler that respects the signal/slot firing rules
+- Slot aggregation (a node with multiple inputs waits for all)
+- Forwarding pointers for live factoring
+- Integration with the autonomy model (approve gates block signal propagation until human acts)
+
+---
+
+## 6. Autonomy Model (arch \S7)
+
+Annotation on the factoring 2-cell, not on the morphism itself:
+
+- **auto**: agent factors and proceeds
+- **approve**: agent proposes, human reviews before factoring takes effect
+- **manual**: human draws the split
+
+### Human feedback type
+
+```
+human_review: Proposal -> Approved(Factoring)
+                        + Rejected(Reason)
+                        + Edited(ModifiedFactoring)
+                        + Restructured(AlternativeFactoring)
+```
+
+### Escalation
+
+An agent in `auto` whose trace isn't converging promotes itself to `approve`. Autonomy is a floor, not a ceiling.
+
+### No inter-agent communication
+
+Typed boundaries are the complete interface contract. Agents are scoped: input type, output type, nothing else.
+
+---
+
+## 7. Morphism Persistence (arch \S8)
+
+The architecture specifies markdown-as-truth with derived SQLite index (extending PR 32's `store.ts` pattern):
+
+### Morphism file format
+
+```markdown
+---
+id: implement_auth
+domain: APISpec ⊗ SecurityReqs
+codomain: CompilingTypeScript<AuthMiddleware>
+autonomy: auto
+status: pending
+factored_from: implement_backend
+validator:
+  kind: tensor
+  checks:
+    - { kind: command, command: tsc, args: ["--noEmit", "src/auth.ts"], expectedExit: 0 }
+    - { kind: command, command: jest, args: ["--testPathPattern", "auth"], expectedExit: 0 }
+---
+
+Implement JWT auth middleware.
+
+## Decision log
+- httpOnly cookies over localStorage (compliance)
+- JWT over sessions (stateless scaling)
+```
+
+Files live in `.zygomorphic/plan/`. The dependency graph is derived (SQLite), rebuilt from morphism files. Execution state is in-memory and ephemeral. Factoring history is `git log` of morphism files.
+
+PR 32's `store.ts` already implements the markdown-as-truth + SQLite-as-index pattern for workspace nodes. The morphism persistence layer follows the same pattern with different frontmatter keys and a different directory.
+
+---
+
+## 8. Git Integration (arch \S8)
+
+- Tensor decomposition produces parallel git branches (enforces causal isolation)
+- Typed boundary validation runs as CI checks on PRs
+- Composition (sequential work) merges a PR
+- `git log --follow .zygomorphic/plan/` = factoring history
+
+This is architecturally independent of the categorical core -- it's an integration layer that maps categorical operations to git operations. But it's load-bearing for the tensor isolation guarantee.
+
+---
+
+## 9. Type Refinement Ratchet (arch \S6.4)
+
+Types start weak and get refined through failure:
+
+```
+Attempt 1: Spec -> Code                           (too loose)
+Attempt 2: Spec -> CompilingCode                   (tighter)
+Attempt 3: Spec ⊗ APIConstraints -> CompilingCode<I>   (learned from failure)
+```
+
+Types are cumulative learning. Each failure tightens the validator. Type bloat signals wrong factoring -- pressure toward better decomposition.
+
+This is not a separate component but a behavioral property that emerges from:
+- The conditional trace (retry feeds back error context)
+- The `none` validator (forces factoring)
+- The 2-cell structure (factoring introduces intermediate types)
+- The validator-as-type principle (tighter validator = tighter type)
+
+---
+
+## 10. Validation Impossibility Drives Factoring (arch \S6.3)
+
+A morphism whose codomain has `validator: { kind: 'none' }` CANNOT execute -- it must factor. The tree grows downward until every leaf has a constructible validator. The frontier of unfactored morphisms IS the set of morphisms with unvalidatable codomains.
+
+Two failure modes, two mechanisms:
+- "I tried and failed the check" -> trace iterates (local)
+- "There is no check" -> must factor (structural)
+
+---
+
+## Priority ordering
+
+1. **ArtifactType + ValidatorSpec** -- foundation everything else builds on
+2. **Conditional trace** -- the key semantic primitive; without it the retry/guarantee model doesn't work
+3. **2-cell structure** -- factor/fuse with typed boundaries; required for any planning operations
+4. **Generic CellOps** -- unifies level 1 and 2; mechanical once the 2-cell type exists
+5. **Signal/slot executor** -- highest effort but architecturally independent; can develop against the categorical core once 1-4 are solid
+6. **Autonomy model** -- layered on top of 2-cells and executor
+7. **Morphism persistence** -- extends store.ts pattern; moderate effort
+8. **Git integration** -- integration layer; last mile
+9. **Type refinement** -- emergent from the above; verify it works, don't build it separately
+
+---
+
+## What tropical tests cover and what new tests are needed
+
+### Migrates from tropical
+- Property-based categorical law verification (identity, associativity, interchange, unit)
+- Optimizer type preservation and idempotence proofs
+- MorphismRegistry register/find/canonical tests
+
+### New test requirements
+- Conditional trace: sum-type exit/retry semantics, convergence guarantees
+- 2-cell type checker: boundary preservation under factor/fuse/vertical/horizontal composition
+- CellOps generic instantiation: same test suite runs at both levels
+- Signal/slot executor: firing rules, slot aggregation, concurrent tensor execution, live factoring
+- Validator execution: each of the 6 kinds, composed validators, `none` rejection
+- Autonomy: escalation triggers, approve gates, human feedback routing

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ajv": "^8.18.0",
         "better-sqlite3": "^12.8.0",
         "electron": "^34.0.0",
         "pg": "^8.20.0"
@@ -72,6 +73,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
@@ -1253,28 +1288,6 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
@@ -2265,16 +2278,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2296,38 +2308,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -3592,6 +3572,32 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dmg-license/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/dmg-license/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -5124,10 +5130,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ajv": "^8.18.0",
     "better-sqlite3": "^12.8.0",
     "electron": "^34.0.0",
     "pg": "^8.20.0"

--- a/src/kernel/__tests__/live-factoring.test.ts
+++ b/src/kernel/__tests__/live-factoring.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { signalExecute, LiveFactoringTable, FactoringError } from '../signal-executor.js';
+import type { Artifact, BodyExecutor } from '../types.js';
+import { morphism, compose, tensor, productType } from '../types.js';
+import type { ArtifactType } from '../types.js';
+
+// --- Fixture types ---
+
+const Raw: ArtifactType = { name: 'Raw', validator: { kind: 'none' } };
+const JSON_: ArtifactType = { name: 'JSON', validator: { kind: 'schema' } };
+const Compiled: ArtifactType = {
+  name: 'Compiled',
+  validator: { kind: 'command', command: 'true', args: [], expectedExit: 0 },
+};
+
+// A mock body executor: records which morphism names fired and returns JSON.
+function makeRecordingExecutor(log: string[]) {
+  const exec: BodyExecutor = async (body) => {
+    const name = body.kind === 'agent' ? body.prompt
+      : body.kind === 'tool' ? body.command
+      : 'unknown';
+    log.push(name);
+    return '{}';
+  };
+  return exec;
+}
+
+// ---
+
+describe('LiveFactoringTable.factor — type boundary validation', () => {
+  it('accepts a replacement with matching dom/cod', () => {
+    const table = new LiveFactoringTable();
+    const original = morphism('gen', Raw, JSON_, { kind: 'agent', prompt: 'gen' });
+    const replacement = compose(
+      morphism('step1', Raw, JSON_, { kind: 'agent', prompt: 'step1' }),
+      morphism('step2', JSON_, JSON_, { kind: 'tool', command: 'step2', args: [] }),
+    );
+    expect(() =>
+      table.factor('gen', replacement, { dom: original.dom, cod: original.cod })
+    ).not.toThrow();
+  });
+
+  it('rejects a replacement with wrong domain', () => {
+    const table = new LiveFactoringTable();
+    const replacement = morphism('wrong', Compiled, JSON_, { kind: 'agent', prompt: 'x' });
+    expect(() =>
+      table.factor('gen', replacement, { dom: Raw, cod: JSON_ })
+    ).toThrow(FactoringError);
+  });
+
+  it('rejects a replacement with wrong codomain', () => {
+    const table = new LiveFactoringTable();
+    const replacement = morphism('wrong', Raw, Compiled, { kind: 'agent', prompt: 'x' });
+    expect(() =>
+      table.factor('gen', replacement, { dom: Raw, cod: JSON_ })
+    ).toThrow(FactoringError);
+  });
+});
+
+describe('LiveFactoringTable — state management', () => {
+  let table: LiveFactoringTable;
+
+  beforeEach(() => { table = new LiveFactoringTable(); });
+
+  it('isActive returns false before factoring', () => {
+    expect(table.isActive('gen')).toBe(false);
+  });
+
+  it('isActive returns true after factoring', () => {
+    const m = morphism('gen', Raw, JSON_, { kind: 'agent', prompt: 'gen' });
+    table.factor('gen', m, { dom: Raw, cod: JSON_ });
+    expect(table.isActive('gen')).toBe(true);
+    expect(table.size).toBe(1);
+  });
+
+  it('rewind removes the pointer', () => {
+    const m = morphism('gen', Raw, JSON_, { kind: 'agent', prompt: 'gen' });
+    table.factor('gen', m, { dom: Raw, cod: JSON_ });
+    table.rewind('gen');
+    expect(table.isActive('gen')).toBe(false);
+    expect(table.size).toBe(0);
+  });
+});
+
+describe('forwarding pointer: basic redirect', () => {
+  it('executes replacement instead of original body', async () => {
+    const log: string[] = [];
+    const executor = makeRecordingExecutor(log);
+
+    const original = morphism('gen', Raw, JSON_, { kind: 'agent', prompt: 'original' });
+    const replacement = morphism('gen-factored', Raw, JSON_, { kind: 'agent', prompt: 'factored' });
+
+    const table = new LiveFactoringTable();
+    table.factor('gen', replacement, { dom: Raw, cod: JSON_ });
+
+    await signalExecute(original, { type: Raw, value: 'x' }, executor, { liveFactoring: table });
+
+    expect(log).toEqual(['factored']);
+    expect(log).not.toContain('original');
+  });
+
+  it('without factoring, original body fires', async () => {
+    const log: string[] = [];
+    const executor = makeRecordingExecutor(log);
+
+    const original = morphism('gen', Raw, JSON_, { kind: 'agent', prompt: 'original' });
+
+    await signalExecute(original, { type: Raw, value: 'x' }, executor);
+
+    expect(log).toEqual(['original']);
+  });
+});
+
+describe('forwarding pointer: composition', () => {
+  it('factors one morphism in a pipeline, others unchanged', async () => {
+    const log: string[] = [];
+    const executor = makeRecordingExecutor(log);
+
+    const f = morphism('f', Raw, JSON_, { kind: 'agent', prompt: 'f' });
+    const g = morphism('g', JSON_, JSON_, { kind: 'tool', command: 'g', args: [] });
+    const pipeline = compose(f, g);
+
+    // Factor g into two steps
+    const g1 = morphism('g1', JSON_, JSON_, { kind: 'tool', command: 'g1', args: [] });
+    const g2 = morphism('g2', JSON_, JSON_, { kind: 'tool', command: 'g2', args: [] });
+    const gReplacement = compose(g1, g2);
+
+    const table = new LiveFactoringTable();
+    table.factor('g', gReplacement, { dom: JSON_, cod: JSON_ });
+
+    await signalExecute(pipeline, { type: Raw, value: 'x' }, executor, { liveFactoring: table });
+
+    // f runs normally, g is replaced by g1 then g2
+    expect(log).toEqual(['f', 'g1', 'g2']);
+  });
+
+  it('factors replacement term recursively (nested factoring)', async () => {
+    const log: string[] = [];
+    const executor = makeRecordingExecutor(log);
+
+    const f = morphism('f', Raw, JSON_, { kind: 'agent', prompt: 'f' });
+
+    // Factor f → compose(a, b), then also factor a → compose(a1, a2)
+    const a = morphism('a', Raw, JSON_, { kind: 'agent', prompt: 'a' });
+    const b = morphism('b', JSON_, JSON_, { kind: 'tool', command: 'b', args: [] });
+    const a1 = morphism('a1', Raw, JSON_, { kind: 'agent', prompt: 'a1' });
+    const a2 = morphism('a2', JSON_, JSON_, { kind: 'tool', command: 'a2', args: [] });
+
+    const table = new LiveFactoringTable();
+    table.factor('f', compose(a, b), { dom: Raw, cod: JSON_ });
+    table.factor('a', compose(a1, a2), { dom: Raw, cod: JSON_ });
+
+    await signalExecute(f, { type: Raw, value: 'x' }, executor, { liveFactoring: table });
+
+    expect(log).toEqual(['a1', 'a2', 'b']);
+  });
+});
+
+describe('forwarding pointer: rewind restores original', () => {
+  it('after rewind, original body fires again', async () => {
+    const log: string[] = [];
+    const executor = makeRecordingExecutor(log);
+
+    const original = morphism('m', Raw, JSON_, { kind: 'agent', prompt: 'original' });
+    const replacement = morphism('m-new', Raw, JSON_, { kind: 'agent', prompt: 'replacement' });
+
+    const table = new LiveFactoringTable();
+    table.factor('m', replacement, { dom: Raw, cod: JSON_ });
+
+    await signalExecute(original, { type: Raw, value: 'x' }, executor, { liveFactoring: table });
+    expect(log).toEqual(['replacement']);
+
+    table.rewind('m');
+    await signalExecute(original, { type: Raw, value: 'x' }, executor, { liveFactoring: table });
+    expect(log).toEqual(['replacement', 'original']);
+  });
+});
+
+describe('forwarding pointer: tensor branches factored independently', () => {
+  it('factors left tensor branch without affecting right', async () => {
+    const log: string[] = [];
+    const executor = makeRecordingExecutor(log);
+
+    const left = morphism('left', Raw, JSON_, { kind: 'agent', prompt: 'left-original' });
+    const right = morphism('right', Raw, JSON_, { kind: 'agent', prompt: 'right-original' });
+    const par = tensor(left, right);
+
+    const leftReplacement = morphism('left-new', Raw, JSON_, { kind: 'agent', prompt: 'left-factored' });
+
+    const table = new LiveFactoringTable();
+    table.factor('left', leftReplacement, { dom: Raw, cod: JSON_ });
+
+    const input: Artifact = {
+      type: productType([Raw, Raw]),
+      value: ['a', 'b'],
+    };
+
+    await signalExecute(par, input, executor, { liveFactoring: table });
+
+    expect(log).toContain('left-factored');
+    expect(log).toContain('right-original');
+    expect(log).not.toContain('left-original');
+  });
+});
+
+describe('forwarding pointer: in-flight safety', () => {
+  it('factoring registered mid-execution only affects subsequent calls', async () => {
+    const table = new LiveFactoringTable();
+    const order: string[] = [];
+
+    const fast = morphism('fast', Raw, JSON_, { kind: 'agent', prompt: 'fast' });
+    const slow = morphism('slow', Raw, JSON_, { kind: 'agent', prompt: 'slow' });
+    const pipeline = tensor(fast, slow);
+
+    const fastReplacement = morphism('fast-new', Raw, JSON_, { kind: 'agent', prompt: 'fast-new' });
+
+    const executor: BodyExecutor = async (body) => {
+      const name = body.kind === 'agent' ? body.prompt : 'unknown';
+      if (name === 'slow') {
+        // slow starts, registers factoring for fast while fast may already be running
+        table.factor('fast', fastReplacement, { dom: Raw, cod: JSON_ });
+        order.push('slow');
+      } else {
+        order.push(name);
+      }
+      return '{}';
+    };
+
+    await signalExecute(pipeline, { type: productType([Raw, Raw]), value: ['a', 'b'] }, executor, {
+      liveFactoring: table,
+    });
+
+    // fast fired before slow registered the factoring, so it ran as original
+    // (or as replacement if slow happened first — either way no crash)
+    expect(order.length).toBe(2);
+    expect(order).toContain('slow');
+  });
+});

--- a/src/kernel/__tests__/live-factoring.test.ts
+++ b/src/kernel/__tests__/live-factoring.test.ts
@@ -30,13 +30,12 @@ function makeRecordingExecutor(log: string[]) {
 describe('LiveFactoringTable.factor — type boundary validation', () => {
   it('accepts a replacement with matching dom/cod', () => {
     const table = new LiveFactoringTable();
-    const original = morphism('gen', Raw, JSON_, { kind: 'agent', prompt: 'gen' });
     const replacement = compose(
       morphism('step1', Raw, JSON_, { kind: 'agent', prompt: 'step1' }),
       morphism('step2', JSON_, JSON_, { kind: 'tool', command: 'step2', args: [] }),
     );
     expect(() =>
-      table.factor('gen', replacement, { dom: original.dom, cod: original.cod })
+      table.factor('gen', replacement, { dom: Raw, cod: JSON_ })
     ).not.toThrow();
   });
 

--- a/src/kernel/__tests__/signal-executor.test.ts
+++ b/src/kernel/__tests__/signal-executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { signalExecute, ExecutionError } from '../signal-executor.js';
+import { signalExecute, ExecutionError, EscalationError } from '../signal-executor.js';
 import type { Artifact, BodyExecutor, SumValue } from '../signal-executor.js';
 import { morphism, compose, tensor, trace, id, productType, sumType, UnitType } from '../types.js';
 import type { ArtifactType } from '../types.js';
@@ -264,7 +264,7 @@ describe('signalExecute — trace (conditional retry)', () => {
     const input: Artifact = { type: RawText, value: 'task' };
 
     await expect(
-      signalExecute(t, input, infiniteExecutor, { maxTraceIterations: 5 }),
+      signalExecute(t, input, infiniteExecutor, { maxTraceIterations: 5, escalationThreshold: 10 }),
     ).rejects.toThrow(/did not converge after 5 iterations/);
   });
 
@@ -283,6 +283,80 @@ describe('signalExecute — trace (conditional retry)', () => {
     const input: Artifact = { type: RawText, value: 'task' };
 
     await expect(signalExecute(t, input, badExecutor)).rejects.toThrow(/SumValue/);
+  });
+});
+
+// --- Escalation ---
+
+describe('signalExecute — escalation', () => {
+  const S: ArtifactType = { name: 'S', validator: { kind: 'none' } };
+  const B: ArtifactType = { name: 'B', validator: { kind: 'schema' } };
+
+  function makeBody() {
+    const bodyDom = productType([RawText, S]);
+    const bodyCod = sumType(B, S);
+    return morphism('diverge', bodyDom, bodyCod, { kind: 'agent', prompt: 'loop' });
+  }
+
+  const neverExitExecutor: BodyExecutor = async () =>
+    ({ tag: 'right', value: 'still going' } as SumValue);
+
+  it('throws EscalationError when threshold is reached', async () => {
+    const body = makeBody();
+    const input: Artifact = { type: RawText, value: 'task' };
+
+    await expect(
+      signalExecute(
+        trace(S, null, body),
+        input,
+        neverExitExecutor,
+        { maxTraceIterations: 20, escalationThreshold: 5 },
+      ),
+    ).rejects.toThrow(EscalationError);
+  });
+
+  it('EscalationError carries iteration count and current state', async () => {
+    const body = makeBody();
+    const input: Artifact = { type: RawText, value: 'task' };
+
+    let caught: EscalationError | null = null;
+    try {
+      await signalExecute(
+        trace(S, 'initial-state', body),
+        input,
+        neverExitExecutor,
+        { maxTraceIterations: 20, escalationThreshold: 3 },
+      );
+    } catch (e) {
+      if (e instanceof EscalationError) caught = e;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught!.iterations).toBe(3);
+    // State after 3 right-injections is still 'still going' (last right value)
+    expect(caught!.currentState).toBe('still going');
+  });
+
+  it('does not escalate when convergence happens before threshold', async () => {
+    const body = makeBody();
+    const input: Artifact = { type: RawText, value: 'task' };
+    let attempts = 0;
+
+    const convergesAtTwo: BodyExecutor = async () => {
+      attempts++;
+      if (attempts < 2) return { tag: 'right', value: 'retry' } as SumValue;
+      return { tag: 'left', value: '{}' } as SumValue;
+    };
+
+    const result = await signalExecute(
+      trace(S, null, body),
+      input,
+      convergesAtTwo,
+      { maxTraceIterations: 20, escalationThreshold: 5 },
+    );
+
+    expect(attempts).toBe(2);
+    expect(result.value).toBe('{}');
   });
 });
 

--- a/src/kernel/__tests__/trace.test.ts
+++ b/src/kernel/__tests__/trace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { executeTerm } from '../executor.js';
-import type { Artifact, BodyExecutor } from '../executor.js';
+import { signalExecute } from '../signal-executor.js';
+import type { Artifact, BodyExecutor } from '../types.js';
 import { morphism, compose, trace, left, right, sumType, productType } from '../types.js';
 import type { ArtifactType } from '../types.js';
 
@@ -21,7 +21,7 @@ const RawAndError = productType([Raw, Error]);
 describe('executeTerm: id passthrough', () => {
   it('returns input unchanged', async () => {
     const input: Artifact = { type: Raw, value: 'hello' };
-    const result = await executeTerm({ tag: 'id', portType: Raw }, input, async () => '');
+    const result = await signalExecute({ tag: 'id', portType: Raw }, input, async () => '');
     expect(result.value).toBe('hello');
   });
 });
@@ -30,7 +30,7 @@ describe('executeTerm: single morphism', () => {
   it('runs body and validates output', async () => {
     const m = morphism('gen', Raw, Valid, { kind: 'agent', prompt: 'go' });
     const executor: BodyExecutor = async () => '{"ok":true}';
-    const result = await executeTerm(m, { type: Raw, value: 'in' }, executor);
+    const result = await signalExecute(m, { type: Raw, value: 'in' }, executor);
     expect(result.type).toBe(Valid);
     expect(result.value).toBe('{"ok":true}');
   });
@@ -45,7 +45,7 @@ describe('executeTerm: compose', () => {
       calls.push(body.kind === 'agent' ? 'agent' : 'tool');
       return '{}';
     };
-    await executeTerm(compose(f, g), { type: Raw, value: 'x' }, executor);
+    await signalExecute(compose(f, g), { type: Raw, value: 'x' }, executor);
     expect(calls).toEqual(['agent', 'tool']);
   });
 });
@@ -57,7 +57,7 @@ describe('conditional trace: exits on left', () => {
 
     const executor: BodyExecutor = async () => left('{"result":"done"}');
 
-    const result = await executeTerm(
+    const result = await signalExecute(
       trace(Error, '""', body),
       { type: Raw, value: 'input' },
       executor,
@@ -84,7 +84,7 @@ describe('conditional trace: retries then exits', () => {
       return left('{"final":true}');
     };
 
-    const result = await executeTerm(
+    const result = await signalExecute(
       trace(Error, 'null', body),
       { type: Raw, value: 'start' },
       executor,
@@ -110,7 +110,7 @@ describe('conditional trace: state is threaded correctly', () => {
       return left('{}');
     };
 
-    await executeTerm(
+    await signalExecute(
       trace(Error, '"initial"', body),
       { type: Raw, value: 'x' },
       executor,
@@ -126,7 +126,7 @@ describe('conditional trace: convergence guard', () => {
     const executor: BodyExecutor = async () => right('""');
 
     await expect(
-      executeTerm(trace(Error, '""', body), { type: Raw, value: 'x' }, executor, 5),
+      signalExecute(trace(Error, '""', body), { type: Raw, value: 'x' }, executor, { maxTraceIterations: 5, escalationThreshold: 10 }),
     ).rejects.toThrow(/did not converge.*5/i);
   });
 });
@@ -137,7 +137,7 @@ describe('conditional trace: non-SumValue output throws', () => {
     const executor: BodyExecutor = async () => '{"this":"is not a SumValue"}';
 
     await expect(
-      executeTerm(trace(Error, '""', body), { type: Raw, value: 'x' }, executor),
+      signalExecute(trace(Error, '""', body), { type: Raw, value: 'x' }, executor),
     ).rejects.toThrow(/SumValue/);
   });
 });
@@ -167,7 +167,7 @@ describe('conditional trace: compose inside trace body', () => {
       return left(JSON.stringify({ validated: true, attempt }));
     };
 
-    const result = await executeTerm(
+    const result = await signalExecute(
       trace(Error, 'null', body),
       { type: Raw, value: 'spec' },
       executor,

--- a/src/kernel/__tests__/trace.test.ts
+++ b/src/kernel/__tests__/trace.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { executeTerm } from '../executor.js';
+import type { Artifact, BodyExecutor } from '../executor.js';
+import { morphism, compose, trace, left, right, sumType, productType } from '../types.js';
+import type { ArtifactType } from '../types.js';
+
+// --- Types ---
+
+const Raw: ArtifactType = { name: 'Raw', validator: { kind: 'none' } };
+const Valid: ArtifactType = { name: 'Valid', validator: { kind: 'schema' } };
+const Error: ArtifactType = { name: 'Error', validator: { kind: 'schema' } };
+
+// B + S where B = Valid, S = Error
+const ValidOrError = sumType(Valid, Error);
+
+// A⊗S input to trace body: Raw ⊗ Error
+const RawAndError = productType([Raw, Error]);
+
+// ---
+
+describe('executeTerm: id passthrough', () => {
+  it('returns input unchanged', async () => {
+    const input: Artifact = { type: Raw, value: 'hello' };
+    const result = await executeTerm({ tag: 'id', portType: Raw }, input, async () => '');
+    expect(result.value).toBe('hello');
+  });
+});
+
+describe('executeTerm: single morphism', () => {
+  it('runs body and validates output', async () => {
+    const m = morphism('gen', Raw, Valid, { kind: 'agent', prompt: 'go' });
+    const executor: BodyExecutor = async () => '{"ok":true}';
+    const result = await executeTerm(m, { type: Raw, value: 'in' }, executor);
+    expect(result.type).toBe(Valid);
+    expect(result.value).toBe('{"ok":true}');
+  });
+});
+
+describe('executeTerm: compose', () => {
+  it('chains two morphisms', async () => {
+    const f = morphism('f', Raw, Valid, { kind: 'agent', prompt: 'step1' });
+    const g = morphism('g', Valid, Valid, { kind: 'tool', command: 'jq', args: [] });
+    const calls: string[] = [];
+    const executor: BodyExecutor = async (body) => {
+      calls.push(body.kind === 'agent' ? 'agent' : 'tool');
+      return '{}';
+    };
+    await executeTerm(compose(f, g), { type: Raw, value: 'x' }, executor);
+    expect(calls).toEqual(['agent', 'tool']);
+  });
+});
+
+describe('conditional trace: exits on left', () => {
+  it('exits immediately when body returns left', async () => {
+    // body: Raw⊗Error -> Valid+Error
+    const body = morphism('attempt', RawAndError, ValidOrError, { kind: 'agent', prompt: 'try' });
+
+    const executor: BodyExecutor = async () => left('{"result":"done"}');
+
+    const result = await executeTerm(
+      trace(Error, '""', body),
+      { type: Raw, value: 'input' },
+      executor,
+    );
+
+    expect(result.type.name).toBe('Valid');
+    expect(result.value).toBe('{"result":"done"}');
+  });
+});
+
+describe('conditional trace: retries then exits', () => {
+  it('feeds back state on right, exits on left after N retries', async () => {
+    const body = morphism('attempt', RawAndError, ValidOrError, { kind: 'agent', prompt: 'try' });
+
+    let callCount = 0;
+    const executor: BodyExecutor = async (_body, input) => {
+      callCount++;
+      const [, state] = input.value as [unknown, unknown];
+      // First two calls: return right (retry with updated error state)
+      // Third call: return left (success)
+      if (callCount < 3) {
+        return right(JSON.stringify({ attempt: callCount, prev: state }));
+      }
+      return left('{"final":true}');
+    };
+
+    const result = await executeTerm(
+      trace(Error, 'null', body),
+      { type: Raw, value: 'start' },
+      executor,
+    );
+
+    expect(callCount).toBe(3);
+    expect(result.value).toBe('{"final":true}');
+  });
+});
+
+describe('conditional trace: state is threaded correctly', () => {
+  it('passes updated state back into body each iteration', async () => {
+    const body = morphism('attempt', RawAndError, ValidOrError, { kind: 'agent', prompt: 'x' });
+
+    const statesSeen: unknown[] = [];
+    let calls = 0;
+
+    const executor: BodyExecutor = async (_body, input) => {
+      const [, state] = input.value as [unknown, unknown];
+      statesSeen.push(state);
+      calls++;
+      if (calls < 3) return right(`"error-${calls}"`);
+      return left('{}');
+    };
+
+    await executeTerm(
+      trace(Error, '"initial"', body),
+      { type: Raw, value: 'x' },
+      executor,
+    );
+
+    expect(statesSeen).toEqual(['"initial"', '"error-1"', '"error-2"']);
+  });
+});
+
+describe('conditional trace: convergence guard', () => {
+  it('throws after maxIterations with no left exit', async () => {
+    const body = morphism('loop', RawAndError, ValidOrError, { kind: 'agent', prompt: 'x' });
+    const executor: BodyExecutor = async () => right('""');
+
+    await expect(
+      executeTerm(trace(Error, '""', body), { type: Raw, value: 'x' }, executor, 5),
+    ).rejects.toThrow(/did not converge.*5/i);
+  });
+});
+
+describe('conditional trace: non-SumValue output throws', () => {
+  it('throws if body does not return a tagged injection', async () => {
+    const body = morphism('bad', RawAndError, ValidOrError, { kind: 'agent', prompt: 'x' });
+    const executor: BodyExecutor = async () => '{"this":"is not a SumValue"}';
+
+    await expect(
+      executeTerm(trace(Error, '""', body), { type: Raw, value: 'x' }, executor),
+    ).rejects.toThrow(/SumValue/);
+  });
+});
+
+describe('conditional trace: compose inside trace body', () => {
+  it('composes prompt_agent and validate as the trace body', async () => {
+    // Mirrors the architecture's canonical trace pattern:
+    //   trace(Error, null, compose(prompt_agent, validate_step))
+    // The intermediate type between the two steps uses a schema validator
+    // (valid JSON) — the agent always produces parseable output.
+    const Attempt: ArtifactType = { name: 'Attempt', validator: { kind: 'schema' } };
+    const AttemptAndError = productType([Raw, Error]);
+    const promptAgent = morphism('prompt', AttemptAndError, Attempt, { kind: 'agent', prompt: 'generate' });
+    const validateStep = morphism('validate', Attempt, ValidOrError, { kind: 'tool', command: 'check', args: [] });
+    const body = compose(promptAgent, validateStep);
+
+    let attempt = 0;
+    const executor: BodyExecutor = async (b, input) => {
+      if (b.kind === 'agent') {
+        attempt++;
+        // Always produce valid JSON so Attempt's schema validator passes
+        const state = (input.value as unknown[])[1];
+        return JSON.stringify({ attempt, prevError: state });
+      }
+      // validate_step: fail first two attempts, succeed on third
+      if (attempt < 3) return right('"error"');
+      return left(JSON.stringify({ validated: true, attempt }));
+    };
+
+    const result = await executeTerm(
+      trace(Error, 'null', body),
+      { type: Raw, value: 'spec' },
+      executor,
+    );
+
+    expect(JSON.parse(result.value as string)).toMatchObject({ validated: true, attempt: 3 });
+  });
+});

--- a/src/kernel/__tests__/validate.test.ts
+++ b/src/kernel/__tests__/validate.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { validate } from '../validate.js';
+import type { ValidatorSpec } from '../types.js';
+
+describe('none', () => {
+  it('always fails with factoring message', async () => {
+    const result = await validate({ kind: 'none' }, 'anything');
+    expect(result.passed).toBe(false);
+    expect(result.errors![0]).toMatch(/factor/i);
+  });
+});
+
+describe('human', () => {
+  it('always fails and surfaces the prompt', async () => {
+    const result = await validate({ kind: 'human', prompt: 'Is this correct?' }, 'anything');
+    expect(result.passed).toBe(false);
+    expect(result.errors![0]).toContain('Is this correct?');
+  });
+});
+
+describe('schema', () => {
+  it('passes valid JSON with no schema constraint', async () => {
+    const result = await validate({ kind: 'schema' }, '{"x": 1}');
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails non-JSON string', async () => {
+    const result = await validate({ kind: 'schema' }, 'not json');
+    expect(result.passed).toBe(false);
+  });
+
+  it('fails non-string artifact', async () => {
+    const result = await validate({ kind: 'schema' }, 42);
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes when artifact satisfies schema', async () => {
+    const spec: ValidatorSpec = {
+      kind: 'schema',
+      schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+    };
+    const result = await validate(spec, JSON.stringify({ name: 'hello' }));
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when artifact violates schema', async () => {
+    const spec: ValidatorSpec = {
+      kind: 'schema',
+      schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+    };
+    const result = await validate(spec, JSON.stringify({ count: 3 }));
+    expect(result.passed).toBe(false);
+    expect(result.errors).toBeDefined();
+  });
+});
+
+describe('command', () => {
+  it('passes when command exits with expectedExit=0', async () => {
+    const result = await validate(
+      { kind: 'command', command: 'true', args: [], expectedExit: 0 },
+      null,
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when command exits with wrong code', async () => {
+    const result = await validate(
+      { kind: 'command', command: 'false', args: [], expectedExit: 0 },
+      null,
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes when expectedExit matches non-zero exit', async () => {
+    const result = await validate(
+      { kind: 'command', command: 'false', args: [], expectedExit: 1 },
+      null,
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('tensor', () => {
+  it('passes when all checks pass', async () => {
+    const spec: ValidatorSpec = {
+      kind: 'tensor',
+      checks: [
+        { kind: 'schema' },
+        { kind: 'schema' },
+      ],
+    };
+    const result = await validate(spec, '{}');
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails and collects all errors when multiple checks fail', async () => {
+    const spec: ValidatorSpec = {
+      kind: 'tensor',
+      checks: [
+        { kind: 'none' },
+        { kind: 'human', prompt: 'check this' },
+      ],
+    };
+    const result = await validate(spec, 'x');
+    expect(result.passed).toBe(false);
+    expect(result.errors!.length).toBe(2);
+  });
+
+  it('empty tensor passes (monoidal unit)', async () => {
+    const result = await validate({ kind: 'tensor', checks: [] }, null);
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('sequence', () => {
+  it('passes when all steps pass', async () => {
+    const spec: ValidatorSpec = {
+      kind: 'sequence',
+      steps: [
+        { kind: 'schema' },
+        { kind: 'command', command: 'true', args: [], expectedExit: 0 },
+      ],
+    };
+    const result = await validate(spec, '{}');
+    expect(result.passed).toBe(true);
+  });
+
+  it('stops and returns first failure', async () => {
+    let secondRan = false;
+    // Use none as guaranteed failure; second step would also fail but we only see the first
+    const spec: ValidatorSpec = {
+      kind: 'sequence',
+      steps: [
+        { kind: 'none' },
+        { kind: 'human', prompt: 'should not reach' },
+      ],
+    };
+    const result = await validate(spec, 'x');
+    expect(result.passed).toBe(false);
+    // Only one error: the none, not the human
+    expect(result.errors!.length).toBe(1);
+    expect(result.errors![0]).toMatch(/factor/i);
+  });
+});
+
+describe('none forces factoring', () => {
+  it('a morphism codomain with none cannot be validated', async () => {
+    // The semantic invariant: none is not just "fails" — it means the type is
+    // structurally unvalidatable and the morphism must be factored.
+    const result = await validate({ kind: 'none' }, 'any artifact');
+    expect(result.passed).toBe(false);
+    expect(result.errors![0]).toMatch(/factor/i);
+  });
+});

--- a/src/kernel/executor.ts
+++ b/src/kernel/executor.ts
@@ -1,4 +1,5 @@
 import type { ArtifactType, MorphismBody, Term } from './types.js';
+import { productType, isSumValue } from './types.js';
 import { inferType } from './type-check.js';
 import { validate } from './validate.js';
 
@@ -45,6 +46,76 @@ function flatten(term: Term, out: ExecutionNode[]): void {
       throw new Error('Tensor execution requires signal/slot executor (not yet implemented)');
     case 'trace':
       throw new Error('Trace execution requires signal/slot executor (not yet implemented)');
+  }
+}
+
+/**
+ * Execute any term recursively.
+ *
+ * Handles id, morphism, compose, and trace (conditional feedback loop).
+ * Tensor still delegates to the signal/slot executor.
+ *
+ * Trace semantics: body runs with A⊗S input and produces a SumValue.
+ *   left(b)  → exit the loop, return b as the output
+ *   right(s) → update state to s, iterate
+ */
+export async function executeTerm(
+  term: Term,
+  input: Artifact,
+  bodyExecutor: BodyExecutor,
+  maxIterations = 100,
+): Promise<Artifact> {
+  switch (term.tag) {
+    case 'id':
+      return input;
+
+    case 'morphism': {
+      const rawOutput = await bodyExecutor(term.body, input);
+      const result = await validate(term.cod.validator, rawOutput);
+      if (!result.passed) {
+        throw new Error(
+          `Validation failed for morphism "${term.name}": ${result.errors?.join(', ')}`,
+        );
+      }
+      return { type: term.cod, value: rawOutput };
+    }
+
+    case 'compose': {
+      const mid = await executeTerm(term.first, input, bodyExecutor, maxIterations);
+      return executeTerm(term.second, mid, bodyExecutor, maxIterations);
+    }
+
+    case 'tensor':
+      throw new Error('Tensor execution requires signal/slot executor (not yet implemented)');
+
+    case 'trace': {
+      const traceType = inferType(term);  // { dom: A, cod: B }
+      let state: unknown = term.init;
+
+      for (let i = 0; i < maxIterations; i++) {
+        const productInput: Artifact = {
+          type: productType([input.type, term.stateType]),
+          value: [input.value, state],
+        };
+
+        const bodyOutput = await executeTerm(term.body, productInput, bodyExecutor, maxIterations);
+
+        if (!isSumValue(bodyOutput.value)) {
+          throw new Error(
+            `Trace body must produce a SumValue (left/right injection), got: `
+            + JSON.stringify(bodyOutput.value),
+          );
+        }
+
+        if (bodyOutput.value.tag === 'left') {
+          return { type: traceType.cod, value: bodyOutput.value.value };
+        }
+
+        state = bodyOutput.value.value;
+      }
+
+      throw new Error(`Trace did not converge after ${maxIterations} iterations`);
+    }
   }
 }
 

--- a/src/kernel/executor.ts
+++ b/src/kernel/executor.ts
@@ -1,12 +1,7 @@
-import type { ArtifactType, MorphismBody, Term } from './types.js';
-import { productType, isSumValue } from './types.js';
-import { inferType } from './type-check.js';
+import type { Term } from './types.js';
+import type { Artifact, BodyExecutor } from './types.js';
+export type { Artifact, BodyExecutor } from './types.js';
 import { validate } from './validate.js';
-
-export interface Artifact {
-  type: ArtifactType;
-  value: unknown;
-}
 
 export interface ExecutionNode {
   term: Term & { tag: 'morphism' };
@@ -14,8 +9,6 @@ export interface ExecutionNode {
   output: Artifact | null;
   downstream: ExecutionNode | null;
 }
-
-export type BodyExecutor = (body: MorphismBody, input: Artifact) => Promise<unknown>;
 
 /** Flatten a composed term into a linear sequence of morphism nodes, wired in order. */
 export function buildGraph(term: Term): ExecutionNode[] {
@@ -33,7 +26,6 @@ export function buildGraph(term: Term): ExecutionNode[] {
 function flatten(term: Term, out: ExecutionNode[]): void {
   switch (term.tag) {
     case 'id':
-      // Identity is a no-op in execution — pass through
       return;
     case 'morphism':
       out.push({ term, input: null, output: null, downstream: null });
@@ -49,101 +41,21 @@ function flatten(term: Term, out: ExecutionNode[]): void {
   }
 }
 
-/**
- * Execute any term recursively.
- *
- * Handles id, morphism, compose, and trace (conditional feedback loop).
- * Tensor still delegates to the signal/slot executor.
- *
- * Trace semantics: body runs with A⊗S input and produces a SumValue.
- *   left(b)  → exit the loop, return b as the output
- *   right(s) → update state to s, iterate
- */
-export async function executeTerm(
-  term: Term,
-  input: Artifact,
-  bodyExecutor: BodyExecutor,
-  maxIterations = 100,
-): Promise<Artifact> {
-  switch (term.tag) {
-    case 'id':
-      return input;
-
-    case 'morphism': {
-      const rawOutput = await bodyExecutor(term.body, input);
-      const result = await validate(term.cod.validator, rawOutput);
-      if (!result.passed) {
-        throw new Error(
-          `Validation failed for morphism "${term.name}": ${result.errors?.join(', ')}`,
-        );
-      }
-      return { type: term.cod, value: rawOutput };
-    }
-
-    case 'compose': {
-      const mid = await executeTerm(term.first, input, bodyExecutor, maxIterations);
-      return executeTerm(term.second, mid, bodyExecutor, maxIterations);
-    }
-
-    case 'tensor':
-      throw new Error('Tensor execution requires signal/slot executor (not yet implemented)');
-
-    case 'trace': {
-      const traceType = inferType(term);  // { dom: A, cod: B }
-      let state: unknown = term.init;
-
-      for (let i = 0; i < maxIterations; i++) {
-        const productInput: Artifact = {
-          type: productType([input.type, term.stateType]),
-          value: [input.value, state],
-        };
-
-        const bodyOutput = await executeTerm(term.body, productInput, bodyExecutor, maxIterations);
-
-        if (!isSumValue(bodyOutput.value)) {
-          throw new Error(
-            `Trace body must produce a SumValue (left/right injection), got: `
-            + JSON.stringify(bodyOutput.value),
-          );
-        }
-
-        if (bodyOutput.value.tag === 'left') {
-          return { type: traceType.cod, value: bodyOutput.value.value };
-        }
-
-        state = bodyOutput.value.value;
-      }
-
-      throw new Error(`Trace did not converge after ${maxIterations} iterations`);
-    }
-  }
-}
-
-/** Execute a pipeline: fill the first slot, cascade through to the final output. */
+/** Execute a linear pipeline produced by buildGraph. */
 export async function execute(
   graph: ExecutionNode[],
   input: Artifact,
   bodyExecutor: BodyExecutor,
 ): Promise<Artifact> {
-  if (graph.length === 0) {
-    // Pure identity — pass through
-    return input;
-  }
-
-  // Type-check the full term before executing (fail fast at planning time)
-  // This is already done by the caller via inferType, but we validate the input type here
-  const firstNode = graph[0];
-  const lastNode = graph[graph.length - 1];
+  if (graph.length === 0) return input;
 
   let current: Artifact = input;
 
   for (const node of graph) {
     node.input = current;
 
-    // Execute the body
     const rawOutput = await bodyExecutor(node.term.body, current);
 
-    // Validate output against codomain type
     const result = await validate(node.term.cod.validator, rawOutput);
     if (!result.passed) {
       throw new Error(

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -19,7 +19,7 @@ export type { CellOps } from './cell-ops.js';
 export { checkCompose, cellBoundary, isIdentity, CellTypeError } from './cell-ops.js';
 export { termOps, rewriteOps } from './cell-ops-instances.js';
 export type { ExecutionOptions } from './signal-executor.js';
-export { signalExecute, ExecutionError, EscalationError } from './signal-executor.js';
+export { signalExecute, ExecutionError, EscalationError, FactoringError, LiveFactoringTable } from './signal-executor.js';
 export type { HumanFeedback, ApproveGate } from './autonomy.js';
 export { createGate, resolveGate, escalate, canProceed, requiresHuman } from './autonomy.js';
 export type { MorphismStatus, MorphismData } from './morphism-store.js';

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -1,8 +1,8 @@
-export type { ArtifactType, ValidatorSpec, MorphismBody, Autonomy, Term } from './types.js';
-export { id, morphism, compose, tensor, trace, composeAll, tensorAll, UnitType, productType, sumType, isUnit, isSumType, typeToString } from './types.js';
+export type { ArtifactType, ValidatorSpec, MorphismBody, Autonomy, Term, Artifact, BodyExecutor, SumValue } from './types.js';
+export { id, morphism, compose, tensor, trace, composeAll, tensorAll, UnitType, productType, sumType, isUnit, isSumType, isSumValue, left, right, typeToString } from './types.js';
 export type { MorphismType } from './type-check.js';
 export { typesEqual, inferType, typeCheck, TypeError } from './type-check.js';
-export type { Artifact, ExecutionNode, BodyExecutor } from './executor.js';
+export type { ExecutionNode } from './executor.js';
 export { buildGraph, execute } from './executor.js';
 export type { ValidationResult } from './validate.js';
 export { validate } from './validate.js';
@@ -18,8 +18,8 @@ export { id2, factor, fuse, vertical, horizontal, rewriteSource, rewriteTarget, 
 export type { CellOps } from './cell-ops.js';
 export { checkCompose, cellBoundary, isIdentity, CellTypeError } from './cell-ops.js';
 export { termOps, rewriteOps } from './cell-ops-instances.js';
-export type { Artifact as SignalArtifact, SumValue, BodyExecutor as SignalBodyExecutor, ExecutionOptions } from './signal-executor.js';
-export { signalExecute, isSumValue, ExecutionError } from './signal-executor.js';
+export type { ExecutionOptions } from './signal-executor.js';
+export { signalExecute, ExecutionError, EscalationError } from './signal-executor.js';
 export type { HumanFeedback, ApproveGate } from './autonomy.js';
 export { createGate, resolveGate, escalate, canProceed, requiresHuman } from './autonomy.js';
 export type { MorphismStatus, MorphismData } from './morphism-store.js';

--- a/src/kernel/signal-executor.ts
+++ b/src/kernel/signal-executor.ts
@@ -17,43 +17,25 @@
  * structure is encoded in the wiring. Locality is load-bearing.
  */
 
-import type { ArtifactType, MorphismBody, Term } from './types.js';
-import { productType, sumType } from './types.js';
-import { inferType, typesEqual } from './type-check.js';
+import type { ArtifactType, Term, Artifact, BodyExecutor, SumValue } from './types.js';
+import { productType, isSumValue } from './types.js';
+import { inferType } from './type-check.js';
 import { validate } from './validate.js';
+import { escalate } from './autonomy.js';
 
-// --- Runtime value types ---
-
-export interface Artifact {
-  type: ArtifactType;
-  value: unknown;
-}
-
-/**
- * Runtime representation of a sum-type value (B + S).
- * Left injection exits the trace; right injection feeds back.
- */
-export interface SumValue {
-  tag: 'left' | 'right';
-  value: unknown;
-}
-
-export function isSumValue(v: unknown): v is SumValue {
-  return typeof v === 'object' && v !== null && 'tag' in v
-    && ((v as SumValue).tag === 'left' || (v as SumValue).tag === 'right');
-}
-
-// --- Executor interface ---
-
-/**
- * Execute a morphism body given an input artifact. Returns the raw output.
- * For trace bodies, must return a SumValue indicating exit or retry.
- */
-export type BodyExecutor = (body: MorphismBody, input: Artifact) => Promise<unknown>;
+// Re-export consolidated runtime types so callers don't need a second import.
+export type { Artifact, BodyExecutor, SumValue } from './types.js';
+export { isSumValue } from './types.js';
 
 export interface ExecutionOptions {
   /** Maximum trace iterations before aborting. Default: 100. */
   maxTraceIterations?: number;
+  /**
+   * Iteration count at which an auto-autonomy trace escalates.
+   * Escalation throws EscalationError so the caller can route to human review.
+   * Default: half of maxTraceIterations.
+   */
+  escalationThreshold?: number;
 }
 
 // --- Signal/slot executor ---
@@ -120,9 +102,23 @@ export async function signalExecute(
         // Each iteration: body receives [A_value, state], returns SumValue.
         // Left(B) exits. Right(S') retries with new state.
         const bodyType = inferType(t.body);
+        const exitType = inferType(t);
+        const threshold = options.escalationThreshold ?? Math.ceil(maxIter / 2);
         let state: unknown = t.init;
+        // Autonomy starts at auto; escalation may promote it to approve.
+        let autonomy = 'auto' as import('./types.js').Autonomy;
 
         for (let i = 0; i < maxIter; i++) {
+          // Escalation check: auto traces that aren't converging promote to approve.
+          autonomy = escalate(autonomy, i, threshold);
+          if (autonomy !== 'auto') {
+            throw new EscalationError(
+              `Trace did not converge after ${i} iterations — escalating to human review`,
+              i,
+              state,
+            );
+          }
+
           // Build body input: A ⊗ S
           const bodyInput: Artifact = {
             type: bodyType.dom,
@@ -142,8 +138,6 @@ export async function signalExecute(
           const sum = bodyOutput.value;
 
           if (sum.tag === 'left') {
-            // Exit: left injection is the output type B
-            const exitType = inferType({ tag: 'trace', stateType: t.stateType, init: t.init, body: t.body });
             return { type: exitType.cod, value: sum.value };
           }
 
@@ -167,6 +161,21 @@ export class ExecutionError extends Error {
   override name = 'ExecutionError';
   constructor(message: string) {
     super(message);
+  }
+}
+
+/**
+ * Thrown when a trace escalates from auto to approve.
+ * Carries enough context for the caller to route to human review.
+ */
+export class EscalationError extends Error {
+  override name = 'EscalationError';
+  readonly iterations: number;
+  readonly currentState: unknown;
+  constructor(message: string, iterations: number, currentState: unknown) {
+    super(message);
+    this.iterations = iterations;
+    this.currentState = currentState;
   }
 }
 

--- a/src/kernel/signal-executor.ts
+++ b/src/kernel/signal-executor.ts
@@ -19,7 +19,7 @@
 
 import type { ArtifactType, Term, Artifact, BodyExecutor, SumValue } from './types.js';
 import { productType, isSumValue } from './types.js';
-import { inferType } from './type-check.js';
+import { inferType, typesEqual } from './type-check.js';
 import { validate } from './validate.js';
 import { escalate } from './autonomy.js';
 
@@ -36,6 +36,77 @@ export interface ExecutionOptions {
    * Default: half of maxTraceIterations.
    */
   escalationThreshold?: number;
+  /**
+   * Live factoring table. When a morphism has an active forwarding pointer,
+   * its execution is redirected to the replacement term. Append-only and
+   * lock-free: in-flight morphisms complete normally; only future invocations
+   * of the factored name see the new routing.
+   */
+  liveFactoring?: LiveFactoringTable;
+}
+
+// --- Live factoring ---
+
+/**
+ * A runtime forwarding table for mid-execution factoring.
+ *
+ * Maps morphism names to replacement terms. Before firing a morphism,
+ * the executor checks this table. If a pointer exists, the replacement
+ * term is executed in place of the original body.
+ *
+ * Type boundaries are validated at factor() time, not execution time,
+ * so redirected execution always preserves the morphism's typed interface.
+ *
+ * Rewind is localized: rewind(name) removes the pointer; subsequent
+ * invocations revert to the original body.
+ */
+export class LiveFactoringTable {
+  private readonly table = new Map<string, Term>();
+
+  /**
+   * Register a forwarding pointer for morphismName.
+   * replacement must have the same domain and codomain as declared in boundary.
+   */
+  factor(
+    morphismName: string,
+    replacement: Term,
+    boundary: { dom: ArtifactType; cod: ArtifactType },
+  ): void {
+    const replType = inferType(replacement);
+    if (!typesEqual(replType.dom, boundary.dom)) {
+      throw new FactoringError(
+        `Live factoring of "${morphismName}": replacement domain "${replType.dom.name}" `
+        + `does not match expected "${boundary.dom.name}"`,
+      );
+    }
+    if (!typesEqual(replType.cod, boundary.cod)) {
+      throw new FactoringError(
+        `Live factoring of "${morphismName}": replacement codomain "${replType.cod.name}" `
+        + `does not match expected "${boundary.cod.name}"`,
+      );
+    }
+    this.table.set(morphismName, replacement);
+  }
+
+  /** Remove the forwarding pointer. Subsequent invocations use the original body. */
+  rewind(morphismName: string): void {
+    this.table.delete(morphismName);
+  }
+
+  /** Return the replacement term if one is registered, else undefined. */
+  get(morphismName: string): Term | undefined {
+    return this.table.get(morphismName);
+  }
+
+  /** Whether a forwarding pointer is active for this name. */
+  isActive(morphismName: string): boolean {
+    return this.table.has(morphismName);
+  }
+
+  /** Number of active forwarding pointers. */
+  get size(): number {
+    return this.table.size;
+  }
 }
 
 // --- Signal/slot executor ---
@@ -64,6 +135,13 @@ export async function signalExecute(
         return inp;
 
       case 'morphism': {
+        // Forwarding pointer: if this morphism has been factored at runtime,
+        // redirect to the replacement term. In-flight invocations (already
+        // past this check) complete normally — only future calls are redirected.
+        const forwarded = options.liveFactoring?.get(t.name);
+        if (forwarded) {
+          return exec(forwarded, inp);
+        }
         const rawOutput = await bodyExecutor(t.body, inp);
         await validateOutput(t.name, t.cod, rawOutput);
         return { type: t.cod, value: rawOutput };
@@ -159,6 +237,13 @@ export async function signalExecute(
 
 export class ExecutionError extends Error {
   override name = 'ExecutionError';
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class FactoringError extends Error {
+  override name = 'FactoringError';
   constructor(message: string) {
     super(message);
   }

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -101,6 +101,24 @@ export function typeToString(t: ArtifactType): string {
   return t.name;
 }
 
+// --- Runtime sum injection ---
+
+/** Tagged value for sum-type outputs. Left exits a trace; right feeds back. */
+export type SumValue =
+  | { tag: 'left'; value: unknown }
+  | { tag: 'right'; value: unknown }
+
+export const left = (value: unknown): SumValue => ({ tag: 'left', value });
+export const right = (value: unknown): SumValue => ({ tag: 'right', value });
+
+export function isSumValue(x: unknown): x is SumValue {
+  return (
+    typeof x === 'object' && x !== null && 'tag' in x
+    && ((x as { tag: unknown }).tag === 'left' || (x as { tag: unknown }).tag === 'right')
+    && 'value' in x
+  );
+}
+
 // --- Morphisms (1-cells): Terms ---
 
 export type MorphismBody =

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -119,6 +119,20 @@ export function isSumValue(x: unknown): x is SumValue {
   );
 }
 
+// --- Runtime artifact and executor ---
+
+/** A typed value in the execution engine. */
+export interface Artifact {
+  type: ArtifactType;
+  value: unknown;
+}
+
+/**
+ * Execute a morphism body given an input artifact.
+ * For trace bodies (sum-type codomain), must return a SumValue.
+ */
+export type BodyExecutor = (body: MorphismBody, input: Artifact) => Promise<unknown>;
+
 // --- Morphisms (1-cells): Terms ---
 
 export type MorphismBody =

--- a/src/kernel/validate.ts
+++ b/src/kernel/validate.ts
@@ -12,9 +12,11 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { Ajv } from 'ajv';
 import type { ValidatorSpec } from './types.js';
 
 const execFileAsync = promisify(execFile);
+const ajv = new Ajv();
 
 export interface ValidationResult {
   passed: boolean;
@@ -34,8 +36,13 @@ export async function validate(spec: ValidatorSpec, artifact: unknown): Promise<
         return { passed: false, errors: ['Expected string artifact for JSON validation'] };
       }
       try {
-        JSON.parse(artifact);
-        // TODO: validate against spec.schema (JSON Schema) when present
+        const parsed = JSON.parse(artifact);
+        if (spec.schema) {
+          const valid = ajv.validate(spec.schema, parsed);
+          if (!valid) {
+            return { passed: false, errors: ajv.errors!.map(err => `${err.instancePath} ${err.message}`) };
+          }
+        }
         return { passed: true };
       } catch (e) {
         return { passed: false, errors: [(e as Error).message] };

--- a/src/kernel/validate.ts
+++ b/src/kernel/validate.ts
@@ -14,6 +14,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { Ajv } from 'ajv';
 import type { ValidatorSpec } from './types.js';
+import { isSumValue } from './types.js';
 
 const execFileAsync = promisify(execFile);
 const ajv = new Ajv();
@@ -82,7 +83,12 @@ export async function validate(spec: ValidatorSpec, artifact: unknown): Promise<
     }
 
     case 'sum': {
-      // Sum validation: artifact must satisfy either left or right
+      // Tagged injection: validate only the branch that was taken
+      if (isSumValue(artifact)) {
+        const branch = artifact.tag === 'left' ? spec.left : spec.right;
+        return validate(branch, artifact.value);
+      }
+      // Untagged fallback: artifact must satisfy either branch (type-checking use)
       const leftResult = await validate(spec.left, artifact);
       if (leftResult.passed) return { passed: true };
       const rightResult = await validate(spec.right, artifact);


### PR DESCRIPTION
## Summary

- **ValidatorSpec execution**: wires `ajv` into the `schema` validator kind (JSON Schema validation); adds `validate.test.ts` covering all 6 kinds including `none`-forces-factoring invariant
- **Conditional trace** (`A⊗S → B+S`): `SumValue` tagged injections (`left`/`right`) in `types.ts`; trace loop in `signalExecute` exits on left, retries on right; `trace.test.ts` with 9 cases
- **Type consolidation**: `SumValue`, `Artifact`, `BodyExecutor` unified in `types.ts`; `signal-executor.ts` re-exports them; `executeTerm` removed (redundant with `signalExecute`); `SignalArtifact`/`SignalBodyExecutor` aliases gone
- **Autonomy escalation**: trace loop calls `escalate()` at each iteration; throws `EscalationError` (with `iterations` + `currentState`) when `auto` trace exceeds threshold; default threshold is `ceil(maxIter/2)`
- **Live factoring** (`LiveFactoringTable`): forwarding pointer table for runtime graph mutation; `factor(name, replacement, boundary)` validates types at registration; `rewind(name)` restores original; executor checks table before firing each morphism; append-only, lock-free, rewindable

## Test plan

- [ ] CI passes (310 tests across 22 files)
- [ ] `validate.test.ts` — 16 tests, all 6 validator kinds
- [ ] `trace.test.ts` — 9 tests, conditional trace semantics
- [ ] `signal-executor.test.ts` — escalation cases, convergence guard
- [ ] `live-factoring.test.ts` — 13 tests: type validation, rewind, composition, tensor isolation, in-flight safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)